### PR TITLE
Fixes #47 and Adds support for QueryParser options

### DIFF
--- a/src/main/java/com/orientechnologies/lucene/collections/OFullTextCompositeKey.java
+++ b/src/main/java/com/orientechnologies/lucene/collections/OFullTextCompositeKey.java
@@ -22,15 +22,42 @@ import com.orientechnologies.orient.core.command.OCommandContext;
 import com.orientechnologies.orient.core.index.OCompositeKey;
 import com.orientechnologies.orient.core.index.OIndexFullText;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by enricorisa on 16/06/14.
  */
 public class OFullTextCompositeKey extends OLuceneCompositeKey {
 
+  private Map<String, Object> params = new HashMap<String, Object>();
+
   public OFullTextCompositeKey(final List<?> keys) {
     super(keys);
+  }
+
+  public OFullTextCompositeKey setParameters(Object params) {
+    if (params instanceof Map) {
+      for (Object key : ((Map) params).keySet()) {
+        if (key != null) {
+          this.params.put(key.toString().toLowerCase(), ((Map) params).get(key));
+        }
+      }
+
+      if (this.params.containsKey("q")) {
+        this.params.put("query", this.params.get("q"));
+        this.params.remove("q");
+      }
+    } else {
+      this.params.put("query", params.toString());
+    }
+
+    return this;
+  }
+
+  public Map<String, Object> getParameters() {
+    return params;
   }
 
 }

--- a/src/main/java/com/orientechnologies/lucene/manager/OLuceneFullTextIndexManager.java
+++ b/src/main/java/com/orientechnologies/lucene/manager/OLuceneFullTextIndexManager.java
@@ -100,7 +100,7 @@ public class OLuceneFullTextIndexManager extends OLuceneIndexManagerAbstract {
   public Object get(Object key) {
     Query q = null;
     try {
-      q = OLuceneIndexType.createFullQuery(index, key, mgrWriter.getIndexWriter().getAnalyzer(), getLuceneVersion(metadata));
+      q = OLuceneIndexType.createFullTextQuery(index, key, mgrWriter.getIndexWriter().getAnalyzer(), getLuceneVersion(metadata));
       OCommandContext context = null;
       if (key instanceof OFullTextCompositeKey) {
         context = ((OFullTextCompositeKey) key).getContext();

--- a/src/main/java/com/orientechnologies/lucene/operator/OLuceneTextOperator.java
+++ b/src/main/java/com/orientechnologies/lucene/operator/OLuceneTextOperator.java
@@ -48,7 +48,7 @@ public class OLuceneTextOperator extends OQueryTargetOperator {
   @Override
   public OIndexCursor executeIndexQuery(OCommandContext iContext, OIndex<?> index, List<Object> keyParams, boolean ascSortOrder) {
     OIndexCursor cursor;
-    Object indexResult = index.get(new OFullTextCompositeKey(keyParams).setContext(iContext));
+    Object indexResult = index.get(new OFullTextCompositeKey(keyParams).setParameters(keyParams.get(0)).setContext(iContext));
     if (indexResult == null || indexResult instanceof OIdentifiable)
       cursor = new OIndexCursorSingleValue((OIdentifiable) indexResult, new OFullTextCompositeKey(keyParams));
     else


### PR DESCRIPTION
Here is the current query + options syntax:

```sql
SELECT filename FROM hash_table WHERE [block, hash] LUCENE {"q":"block2:768 AND hash2:wemfOGxqCfOTPi0ND~", "LowerCaseExpandedTerms": "false", "ParserType": "classic"}
```

Option terms are case insensitive. 

Added support for the following options:

_ParserType:_ Overrides the default parser type selection based on parentheses in the query in order to allow some specific cases.

Along with all the options exposed by the setter methods of  `org.apache.lucene.queryparser.classic.QueryParserBase`:

_AllowLeadingWildcard, AnalyzeRangeTerms, AutoGeneratePhraseQueries, DateResolution, DateResolution, DefaultOperator, FuzzyMinSim, FuzzyPrefixLength, Locale, LowercaseExpandedTerms, MultiTermRewriteMethod, PhraseSlop, TimeZone_