### PR TITLE
Feature/stopwords

### DIFF
--- a/src/main/java/com/orientechnologies/lucene/manager/OLuceneIndexManagerAbstract.java
+++ b/src/main/java/com/orientechnologies/lucene/manager/OLuceneIndexManagerAbstract.java
@@ -300,7 +300,7 @@ public abstract class OLuceneIndexManagerAbstract<V> extends OSharedResourceAdap
     if (metadata != null && metadata.field("analyzer") != null) {
       final String analyzerString = metadata.field("analyzer");
       if (analyzerString != null) {
-        Version version = getVersion(metadata);
+        Version version = getLuceneVersion(metadata);
 		try {
 		  final Class classAnalyzer = Class.forName(analyzerString);
 


### PR DESCRIPTION
adds the following parameters to FULLTEXT LUCENE METADATA:
- stopwords: an array of words that are excluded from the Index (stopwords)
- mergeDefaultStopwords: a (boolean) switch to define whether the analyzer's default stopwords (e.g. "and", "for", "if"...) should be merged with the user defined stopwords array
- stemExclude: an array of words that should be skipped by the stemmer

Example:
```sql
CREATE INDEX Data.text ON Data (text) FULLTEXT ENGINE LUCENE METADATA {
  analyzer":"org.apache.lucene.analysis.en.EnglishAnalyzer",
  "stopwords": ["every", "because", "until"],
  "mergeDefaultStopwords": true,
  "stemExclude": ["alpha"]
}